### PR TITLE
Allow JSON files to be stored inside sub-directories of config/designtokens

### DIFF
--- a/src/fields/DesignTokensField.php
+++ b/src/fields/DesignTokensField.php
@@ -57,8 +57,8 @@ class DesignTokensField extends Field
 		// Get all of the available configs and return just their filename
 		$configs = collect(DesignTokens::$instance->configs->getAll())
 			->map(function ($path) {
-				$parts = explode("/", $path);
-				return end($parts);
+				$folder = Craft::getAlias("@config") . DIRECTORY_SEPARATOR . "designtokens" . DIRECTORY_SEPARATOR;
+				return str_replace( $folder, '', $path );
 			})
 			->mapWithKeys(fn($filename) => [$filename => $filename])
 			->toArray();


### PR DESCRIPTION
Currently, if you create a sub-directory within `config/designtokens`, the `getAll()` function in the `services/Config.php` will find the nested JSON config files, but the full path to the JSON file doesn't get included when you display (or save) them.

This is because the `FileHelper::findFiles` function searches sub-directories recursively by default.

What's worse, if you attach a Design Token field to your entry, and then select a JSON file from within a sub-directory, the entry editing page starts to break in unusual ways and becomes unusable (in my case, all my Redactor fields refused to load, and the console lit up with JavaScript errors).

Obviously, you could tell `FileHelper` not to search the `config/designtokens` folder recursively, but I think this option provides some additional flexibility for devs to organize files in a way that makes sense to their projects.